### PR TITLE
Change the keyserver pool

### DIFF
--- a/tasks/singularity.yml
+++ b/tasks/singularity.yml
@@ -3,7 +3,7 @@
   become: true
   apt_key:
     id: 'DD95CC430502E37EF840ACEEA5D32F012649A5A9'
-    keyserver: hkp://pool.sks-keyservers.net
+    keyserver: hkp://keyserver.ubuntu.com
 
 - name: Add neurodebian repo
   become: true


### PR DESCRIPTION
The keyserver pools provided by sks-keyservers (https://sks-keyservers.net/) are all gone. In their web site you can read:  "Update 2021-06-21: Due to even more GDPR takedown requests, the DNS records for the pool will no longer be provided at all."
Therefore now the key is taken from http://keyserver.ubuntu.com/